### PR TITLE
chore: add servicetree.yaml manifest

### DIFF
--- a/servicetree.yaml
+++ b/servicetree.yaml
@@ -1,0 +1,32 @@
+service: bhadra  # required, canonical slug — immutable once registered
+displayName: "Bhadra"  # required, human-readable name — README title and GitHub description ("Bhadra is a Vulnerability Management Platform to handle all security issues"); the slug is the name
+description: "Razorpay's vulnerability-management platform — a customised DefectDojo Django application that pulls findings daily from the org's SAST, SCA, container-scanning, DAST and CSPM tools (Semgrep, Dependabot and others), models every GitHub repository as a product and every tool as an engagement so each daily scan lands as a test, and gives AppSec and service owners one triaged view of open findings plus push-to-defect-tracker workflows."  # required, one-sentence description of what the service does — README ("vulnerability management tool … helps to triage vulnerabilities and push findings to defect trackers", the engagement/product/test model, "Bhadra solves that problem by keep on pushing all the results on daily basis from different tools", "All github repo points to any one of Business Unit") and the repo tree, which is a DefectDojo layout (dojo/ with dojo/tools parsers, dojo/settings/settings.dist.py and its VISIBLE_TOOLS_NAME switch, components/, setup/, manage.py, wsgi.py)
+type: service  # required, one of: service | worker | cron | library | pipeline — a deployed Django web application: manage.py + wsgi.py, Dockerfile.django and Dockerfile.nginx, an nginx/ config tree and a k8s/ manifest directory the README describes ("All the application specific and secrets are passed as k8s config. Postgresql used as a k8s statefulset"). No Netra deployment, but Netra reports only prod-white and cde-green, and the k8s manifests are in-repo rather than in kube-manifests
+tier: T2  # required, one of: T0 | T1 | T2 | T3 · Payments Reliability sheet Priority P2 → T2, kept. Consistent with function: an internal AppSec triage surface with no merchant traffic — the scanners themselves (Semgrep, Dependabot, container scanning) keep running and re-push findings daily, so a Bhadra outage delays triage and reporting rather than losing data or breaking a customer flow
+lifecycle: live  # optional, one of: incubating | live | deprecated | retired (default: live)
+
+domain: tech-infra/security  # required, two-level domain/subgroup slug — the Payments Reliability sheet has no BU for this repo and it carries no .github/repo_owners.json, so derived from what the code does (org-wide vulnerability management for AppSec) and from its committers, who are Security/AppSec engineers (manikandan-rajappan, sskop99, Mahlaqa Haque, plus the rzp-security-svc workflow account). Area reused from the already-patched security repos compsec, security-action and rzp-docker-image-inventory
+
+owner:
+  team:  # required, owning team slug — TO FILL: this repo has no CODEOWNERS file, .github/repo_owners.json carries no team slug, and the GitHub repository-teams API is not readable with the current token; ask the POD lead for the owning GitHub team
+  pm:  # product manager — TO FILL: no DevRev runnable, no .github/repo_owners.json and no PM named anywhere in the repo; internal security tooling has no product owner in the usual sense. Ask the AppSec POD lead
+
+links:
+  repo: "https://github.com/razorpay/bhadra"  # canonical GitHub repo URL
+  alerts_repo:  # this service's alert rules in razorpay/alert-rules — TO FILL: no matching ruleset found; add one in razorpay/alert-rules, then link the file here
+  slos:  # SLO definitions — TO FILL: no slo.yaml at this repo root and no sloth ruleset for it under razorpay/alert-rules/slo/prod (the two places SLOs are defined today); add one there and link it here
+  slack_channel: "#tech_security"  # primary Slack channel for this service — 1,534 members, the Security group's channel and the one the already-patched security repos security-action and rzp-docker-image-inventory use. The draft's only candidate, #bhadra-oss, has 2 members and is the open-sourcing channel, not the operating one; the other name matches in the 36,406-channel index (#security-vulnerabilities-management, 5; #appsec-sentinel-stage, 7) are too small to assert. TO VERIFY with the AppSec POD lead that Bhadra traffic belongs in #tech_security rather than a private AppSec channel
+  zenduty_policy:  # Zenduty policy/service name used for paging — TO FILL: the service-to-policy mapping is not in DevRev or alert-rules for this service; it lives in the external Zenduty policies sheet
+  oncall_handle:  # Slack/PagerDuty oncall handle or usergroup — TO FILL: not set on the DevRev runnable
+  runbook:  # link to the incident runbook — TO FILL: no runbook directory for this service in razorpay/rzp-oncall-agent; add one or link the Google Doc / alpha.razorpay.com page
+  api_docs:  # API documentation — TO FILL: no swagger/openapi/proto found in the repo tree; link the API spec or Postman collection
+  dashboard:  # primary dashboard — TO FILL: the draft's Grafana harvest returned no vajra hit for "bhadra" and the repo has no ruleset in razorpay/alert-rules to take a vajra_link from. Bhadra is itself the reporting surface (its own findings dashboard, and the README notes the data is pulled into Looker/Superset), so if a health dashboard is wanted for the Django/Postgres deployment it has to be created first
+  logs_and_traces: "https://razorpay-prod.app.coralogix.in/#/query-new/archive-logs"  # org-standard prod Coralogix — filter subsystem "bhadra"
+  strategy_okr:  # TO FILL: link the FY strategy doc for the owning group.
+  risk_assessment:  # TO FILL: no .agents/skills/risk-assessment in this repo; add the per-repo risk-assessment skill
+  regions:  # per-region links — TO FILL: no prod region deployment found for this service in spinacode or alert-rules; add a block per geography once it ships
+
+dependencies: []  # optional, declared service dependencies — TO FILL: shape: - service: <slug> for internal deps, - vendor: <name> for external (gateways, banks)
+
+
+# Note for the catalog: this is Razorpay's only public repo in this batch (it was open-sourced — see #bhadra-oss) and it is a customised DefectDojo tree rather than in-house code, so upstream DefectDojo CVEs apply to it. Application code has not changed since November 2023; every commit since is housekeeping (security workflow file, .cursorignore, a package.json/yarn.lock touch in March 2026). Confirm with the AppSec POD whether Bhadra is still the live vulnerability-management surface before treating lifecycle: live as current.


### PR DESCRIPTION
Adds the Service Tree manifest (`servicetree.yaml`) to the repo root.

This manifest declares service ownership, tier, domain, and links for the Service Tree registry. Fields not yet sourced are left blank with inline comments.

Part of the Service Tree rollout.

Generated with Claude Code